### PR TITLE
MissingHeaderError instead of TypeError when headers.authorization is missing

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -116,7 +116,7 @@ module.exports = {
       throw new TypeError('request must be a node http.ServerRequest');
 
     if (!request.headers.authorization)
-      throw new TypeError('no authorization header present in the requset');
+      throw new MissingHeaderError('no authorization header present in the requset');
 
     if (options && typeof(options) !== 'object')
       throw new TypeError('options was not an object');

--- a/tst/parser.test.js
+++ b/tst/parser.test.js
@@ -81,7 +81,7 @@ test('no authorization', function(t) {
     try {
       httpSignature.parseRequest(req);
     } catch (e) {
-      t.equal(e.name, 'TypeError');
+      t.equal(e.name, 'MissingHeaderError');
     }
     res.writeHead(200);
     res.end();


### PR DESCRIPTION
I made a small connect middleware wrapper around node-http-signature, and I want to be able to distinguish between programmer errors (e.g., wrong/missing parameters), and a failed attempt to authenticate a request.  lib/parser.js consistently uses `TypeError` instances for the former, and some custom error types for the latter.  The one exception I noticed is that when request.headers.authorization isn't present, a `TypeError` being thrown, rather than, e.g., a `MissingHeaderError`.

For my purposes, there's a pretty trivial workaround (just inspect the message string), but it's also trivial to address in the library itself, so here's a pull request if you agree :)
