### PR TITLE
If x-date is available, discard date and continue parsing the authorization with x-date

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -88,7 +88,7 @@ module.exports = {
    *         "keyId": "foo",
    *         "algorithm": "rsa-sha256",
    *         "headers": [
-   *           "date",
+   *           "date" or "x-date",
    *           "content-md5"
    *         ]
    *       },
@@ -99,7 +99,7 @@ module.exports = {
    * @param {Object} request an http.ServerRequest.
    * @param {Object} options an optional options object with:
    *                   - clockSkew: allowed clock skew in seconds (default 300).
-   *                   - headers: header names to require (default: date).
+   *                   - headers: header names to require (default: date or x-date).
    *                   - algorithms: algorithms to support (default: all).
    * @return {Object} parsed out object (see above).
    * @throws {TypeError} on invalid input.
@@ -109,7 +109,7 @@ module.exports = {
    *                              either in the request headers from the params,
    *                              or not in the params from a required header
    *                              in options.
-   * @throws {ExpiredRequestError} if the value of date exceeds clock skew.
+   * @throws {ExpiredRequestError} if the value of date or x-date exceeds clock skew.
    */
   parseRequest: function(request, options) {
     if (!request || !request.headers)
@@ -118,6 +118,11 @@ module.exports = {
     if (!request.headers.authorization)
       throw new MissingHeaderError('no authorization header present in ' +
                                    'the request');
+
+    if (request.headers['x-date']) {
+        request.headers.date = request.headers['x-date'];
+        console.log("'X-Date' Header was passed, replacing 'Date' with 'X-Date' for Signing");
+    }
 
     if (options && typeof(options) !== 'object')
       throw new TypeError('options was not an object');


### PR DESCRIPTION
Hey Mark,

I went for the simplest possible solution, and I think it fits, and meets your requirements.

Basically, If `x-date` is an available header, discard `date` and continue signing with `x-date` (by setting the value of the `date` header to the value of the `x-date` header).

In this way, all of the other default options and parsing logic require no modification, and, if the `date` header is passed without the `x-date` header, all will be exactly as it was. If both are passed, `x-date` will take priority.
