### PR TITLE
If x-date is available, ignore date and continue parsing the authorization with x-date

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -88,7 +88,7 @@ module.exports = {
    *         "keyId": "foo",
    *         "algorithm": "rsa-sha256",
    *         "headers": [
-   *           "date",
+   *           "date" or "x-date",
    *           "content-md5"
    *         ]
    *       },
@@ -99,7 +99,7 @@ module.exports = {
    * @param {Object} request an http.ServerRequest.
    * @param {Object} options an optional options object with:
    *                   - clockSkew: allowed clock skew in seconds (default 300).
-   *                   - headers: header names to require (default: date).
+   *                   - headers: header names to require (default: date or x-date).
    *                   - algorithms: algorithms to support (default: all).
    * @return {Object} parsed out object (see above).
    * @throws {TypeError} on invalid input.
@@ -109,7 +109,7 @@ module.exports = {
    *                              either in the request headers from the params,
    *                              or not in the params from a required header
    *                              in options.
-   * @throws {ExpiredRequestError} if the value of date exceeds clock skew.
+   * @throws {ExpiredRequestError} if the value of date or x-date exceeds clock skew.
    */
   parseRequest: function(request, options) {
     if (!request || !request.headers)
@@ -124,9 +124,15 @@ module.exports = {
 
     if (!options) {
       options = {
-        clockSkew: 300,
-        headers: ['date']
+        clockSkew: 300
       };
+
+      if (request.headers['x-date']) {
+        options.headers = ['x-date'];
+      } else {
+        options.headers = ['date'];
+      }
+
     } else {
       if (options.clockSkew === undefined) {
         options.clockSkew = 300;
@@ -135,7 +141,11 @@ module.exports = {
       }
 
       if (options.headers === undefined) {
-        options.headers = ['date'];
+        if (request.headers['x-date']) {
+          options.headers = ['x-date'];
+        } else {
+          options.headers = ['date'];
+        }
       } else if (!(options.headers instanceof Array)) {
         throw new TypeError('options.headers must be an array of strings');
       } else {
@@ -218,7 +228,11 @@ module.exports = {
     }
 
     if (!parsed.params.headers || parsed.params.headers === '') {
-      parsed.params.headers = ['date'];
+      if (request.headers['x-date']) {
+        parsed.params.headers = ['x-date'];
+      } else {
+        parsed.params.headers = ['date'];
+      }
     } else {
       parsed.params.headers = parsed.params.headers.split(' ');
     }
@@ -263,8 +277,12 @@ module.exports = {
     }
 
     // Check against the constraints
-    if (request.headers.date) {
-      var date = new Date(request.headers.date);
+    if (request.headers.date || request.headers['x-date']) {
+        if (request.headers['x-date']) {
+          var date = new Date(request.headers['x-date']);
+        } else {
+          var date = new Date(request.headers.date);
+        }
       var now = new Date();
       var skew = Math.abs(now.getTime() - date.getTime());
 


### PR DESCRIPTION
Fix for issue #4 to conditionally use the `x-date` header over the `date` header when working within the `authorization` header if it is available. If not, use the regular `date` header as before.
