### PR TITLE
fix test command in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "main": "lib/index.js",
   "scripts": {
-    "test": "./node_modules/.bin/tap tst/*.js"
+    "test": "tap test/*.js"
   },
   "dependencies": {
     "assert-plus": "0.1.2",


### PR DESCRIPTION
fixes a typo (changes `tst` to `test`) so that the tests run and also removes the unnecessary long path to the tap command -- npm does that for you automatically 
