### PR TITLE
pem => ssh-rsa conversion

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,6 +19,7 @@ module.exports = {
 
   sshKeyToPEM: util.sshKeyToPEM,
   sshKeyFingerprint: util.fingerprint,
+  pemToRsaSSHKey: util.pemToRsaSSHKey,
 
   verify: verify.verifySignature,
   verifySignature: verify.verifySignature

--- a/test/convert.test.js
+++ b/test/convert.test.js
@@ -4,6 +4,7 @@ var test = require('tap').test;
 
 var sshKeyFingerprint = require('../lib/index').sshKeyFingerprint;
 var sshKeyToPEM = require('../lib/index').sshKeyToPEM;
+var pemToRsaSSHKey = require('../lib/index').pemToRsaSSHKey;
 
 
 
@@ -85,11 +86,25 @@ var DSA_1024_PEM = '-----BEGIN PUBLIC KEY-----\n' +
 
 ///--- Tests
 
+test('1024b pem to rsa ssh key', function(t) {
+  t.equal(pemToRsaSSHKey(PEM_1024, 'mark@foo.local'), SSH_1024);
+  t.end();
+});
+
+test('2048b pem to rsa ssh key', function(t) {
+  t.equal(pemToRsaSSHKey(PEM_2048, 'mark@bluesnoop.local'), SSH_2048);
+  t.end();
+});
+
+test('4096b pem to rsa ssh key', function(t) {
+  t.equal(pemToRsaSSHKey(PEM_4096, 'mark@bluesnoop.local'), SSH_4096);
+  t.end();
+});
+
 test('1024b rsa ssh key', function(t) {
   t.equal(sshKeyToPEM(SSH_1024), PEM_1024);
   t.end();
 });
-
 
 test('2048b rsa ssh key', function(t) {
   t.equal(sshKeyToPEM(SSH_2048), PEM_2048);


### PR DESCRIPTION
# summary

this adds an exported function, `pemToRsaSSHKey` that takes a public key in PEM format, and returns an `ssh-rsa` key as a string.
# example

read in my public key to the node console

``` javascript
> var pubkey = fs.readFileSync('/Users/dave/.ssh/id_rsa.pub', 'utf-8')
> console.log(pubkey)
ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC+JUivj9iHGMnZ0eVS3hJ+jy6gHYLqwK5S6K6r/TaF0uuJv5mYEIIqhkEeg17XkYUZDW6Xcy0GdHNDI53DKTZhF4Ki3KnCQCfGYtLlNsQcvZ08WNTzXZDqXRvkIPwaGXppzuIohoI5J0Y1k89UrjfqBaY8n7JK+dAisA+OL/NXtdu6G+l3bQY28xEKTUkHSXpInQGRieS6veDReMlRg9hlpTWviGTx3SF4O0sD5SuggI+g4dYk311j8iR/AodGp0YxSWr694iBCiGJ5RtXbIaLPl2gdgSeKgonmTqdo3jVeMp7XljDxL+XPAf+Y5YbnhPUNd8P8Q8QElUfIwCJJ6hD dave@Operationss-MacBook-Pro.local
```

use this module to convert it to PEM format

``` js
> var httpsig = require('./')
> var pem = httpsig.sshKeyToPEM(pubkey)
> console.log(pem)
-----BEGIN PUBLIC KEY-----
MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAviVIr4/YhxjJ2dHlUt4S
fo8uoB2C6sCuUuiuq/02hdLrib+ZmBCCKoZBHoNe15GFGQ1ul3MtBnRzQyOdwyk2
YReCotypwkAnxmLS5TbEHL2dPFjU812Q6l0b5CD8Ghl6ac7iKIaCOSdGNZPPVK43
6gWmPJ+ySvnQIrAPji/zV7Xbuhvpd20GNvMRCk1JB0l6SJ0BkYnkur3g0XjJUYPY
ZaU1r4hk8d0heDtLA+UroICPoOHWJN9dY/IkfwKHRqdGMUlq+veIgQohieUbV2yG
iz5doHYEnioKJ5k6naN41XjKe15Yw8S/lzwH/mOWG54T1DXfD/EPEBJVHyMAiSeo
QwIDAQAB
-----END PUBLIC KEY-----
```

assert that the original pubkey (with trailing newline removed) is the same as `pemToRsaSSHKey(pem)` (full circle conversion)

``` js
> assert.strictEqual(httpsig.pemToRsaSSHKey(pem, 'dave@Operationss-MacBook-Pro.local'), pubkey.trim())
undefined
>
```
# tests

added test coverage for all 3 `ssh-rsa` keys found in the existing tests

```
$ npm test

> http-signature@0.10.0 test /Users/dave/dev/node-http-signature
> tap test/*.js

ok test/convert.test.js ................................. 9/9
ok test/parser.test.js ................................ 64/64
ok test/signer.test.js .................................. 8/8
ok test/verify.test.js ................................ 22/22
total ............................................... 103/103

ok
```
