### PR TITLE
allow case insensitive match for signature algorithm

### DIFF
--- a/lib/verify.js
+++ b/lib/verify.js
@@ -33,7 +33,7 @@ module.exports = {
       hmac.update(parsedSignature.signingString);
       return (hmac.digest('base64') === parsedSignature.params.signature);
     } else {
-      var verify = crypto.createVerify(alg[0]);
+      var verify = crypto.createVerify(alg[0].toUpperCase());
       verify.update(parsedSignature.signingString);
       return verify.verify(key, parsedSignature.params.signature, 'base64');
     }

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -23,7 +23,7 @@ module.exports = {
     assert.object(parsedSignature, 'parsedSignature');
     assert.string(key, 'key');
 
-    var alg = parsedSignature.algorithm.match(/(HMAC|RSA|DSA)-(\w+)/);
+    var alg = parsedSignature.algorithm.match(/(HMAC|RSA|DSA)-(\w+)/i);
     if (!alg || alg.length !== 3)
       throw new TypeError('parsedSignature: unsupported algorithm ' +
                           parsedSignature.algorithm);


### PR DESCRIPTION
currently the signer uses lowercase `algorithm: rsa-sha256` by default, which is rejected by the match.