### PR TITLE
Bring assert-plus version in line with node-estify

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "tap test/*.js"
   },
   "dependencies": {
-    "assert-plus": "0.1.4",
+    "assert-plus": "^0.1.4",
     "asn1": "0.1.11",
     "ctype": "0.5.3"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Joyent, Inc",
   "name": "http-signature",
   "description": "Reference implementation of Joyent's HTTP Signature Scheme",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "repository": {
     "type": "git",
     "url": "git://github.com/joyent/node-http-signature.git"


### PR DESCRIPTION
A tiny patch to ensure that node-restify and node-http-signature use the same semver filter for assert-plus. All tests pass fine.