### PR TITLE
added (request-target) support to be able to use the library for the ietf draft

### DIFF
--- a/lib/signer.js
+++ b/lib/signer.js
@@ -139,15 +139,20 @@ module.exports = {
 
       var h = options.headers[i].toLowerCase();
 
-      if (h !== 'request-line') {
+      if (h === 'request-line') {
+          value =
+            stringToSign +=
+              request.method + ' ' + request.path + ' HTTP/' + options.httpVersion;
+      } else if (h === '(request-target)') {
+          value =
+            stringToSign +=
+              '(request-target): ' + request.method.toLowerCase() + ' ' + request.path;
+      } else {
         var value = request.getHeader(h);
         if (!value) {
           throw new MissingHeaderError(h + ' was not in the request');
         }
         stringToSign += h + ': ' + value;
-      } else {
-        stringToSign +=
-          request.method + ' ' + request.path + ' HTTP/' + options.httpVersion;
       }
 
       if ((i + 1) < options.headers.length)


### PR DESCRIPTION
I've added support for (request-target) so that this library can also support this spec: http://tools.ietf.org/html/draft-cavage-http-signatures-03

There's a bunch of http-signature libs around and their implementations all float around a bit between that draft and the joyent spec, if you could at least support that spec a bit more too then that would be nice!