### PR TITLE
encode and sign the `ext` option

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -90,6 +90,7 @@ module.exports = {
    *           "date" or "x-date",
    *           "content-md5"
    *         ],
+   *         "ext": "your extension info",
    *         "signature": "base64"
    *       },
    *       "signingString": "ready to be passed to crypto.verify()"

--- a/lib/signer.js
+++ b/lib/signer.js
@@ -23,6 +23,9 @@ var Algorithms = {
 var Authorization =
   'Signature keyId="%s",algorithm="%s",headers="%s",signature="%s"';
 
+var AuthorizationWithExt =
+  'Signature keyId="%s",algorithm="%s",headers="%s",ext="%s",signature="%s"';
+
 
 
 ///--- Specific Errors
@@ -101,6 +104,7 @@ module.exports = {
    *                   - {String} keyId required.
    *                   - {String} key required (either a PEM or HMAC key).
    *                   - {Array} headers optional; defaults to ['date'].
+   *                   - {String} ext optional; elided if not specified.
    *                   - {String} algorithm optional; defaults to 'rsa-sha256'.
    *                   - {String} httpVersion optional; defaults to '1.1'.
    * @return {Boolean} true if Authorization (and optionally Date) were added.
@@ -115,6 +119,7 @@ module.exports = {
     assert.optionalString(options.algorithm, 'options.algorithm');
     assert.string(options.keyId, 'options.keyId');
     assert.optionalArrayOfString(options.headers, 'options.headers');
+    assert.optionalString(options.ext, 'options.ext');
     assert.optionalString(options.httpVersion, 'options.httpVersion');
 
     if (!request.getHeader('Date'))
@@ -166,11 +171,20 @@ module.exports = {
       signature = signer.sign(options.key, 'base64');
     }
 
-    request.setHeader('Authorization', sprintf(Authorization,
+    if (options.ext) {
+      request.setHeader('Authorization', sprintf(AuthorizationWithExt,
+                                               options.keyId,
+                                               options.algorithm,
+                                               options.headers.join(' '),
+                                               options.ext,
+                                               signature));
+    } else {
+      request.setHeader('Authorization', sprintf(Authorization,
                                                options.keyId,
                                                options.algorithm,
                                                options.headers.join(' '),
                                                signature));
+    }
 
     return true;
   }

--- a/test/signer.test.js
+++ b/test/signer.test.js
@@ -83,6 +83,23 @@ test('request line', function(t) {
 });
 
 
+test('ext', function(t) {
+  var req = http.request(httpOptions, function(res) {
+    t.end();
+  });
+  var opts = {
+    keyId: 'Test',
+    key: rsaPrivate,
+    headers: ['date'],
+    ext: uuid().toString()
+  };
+
+  t.ok(httpSignature.sign(req, opts));
+  t.ok(req.getHeader('Authorization'));
+  console.log('> ' + req.getHeader('Authorization'));
+  req.end();
+});
+
 test('hmac', function(t) {
   var req = http.request(httpOptions, function(res) {
     t.end();


### PR DESCRIPTION
The [signing spec/guide](https://github.com/joyent/node-http-signature/blob/master/http_signing.md) indicates that an optional `extensions` can be encoded in an _http signature_ but the reference implementation did not enable such. This pull request modifies the signer to encode the `ext` option if specified by the caller. I also added a signer test and verify test for this scenario.

Regards.