### PR TITLE
Fix for #40, check algorithm against key type in verifySignature

### DIFF
--- a/lib/verify.js
+++ b/lib/verify.js
@@ -16,16 +16,30 @@ module.exports = {
    *
    * @param {Object} parsedSignature the object you got from `parse`.
    * @param {String} key either an RSA private key PEM or HMAC secret.
+   * @param {String} keyType the type of key `rsa`, `dsa` or `hmac`, optional
    * @return {Boolean} true if valid, false otherwise.
-   * @throws {TypeError} if you pass in bad arguments.
+   * @throws {TypeError} if you pass in bad arguments or sig algo doesn't match
    */
-  verifySignature: function verifySignature(parsedSignature, key) {
+  verifySignature: function verifySignature(parsedSignature, key, keyType) {
     assert.object(parsedSignature, 'parsedSignature');
     assert.string(key, 'key');
+    if (!keyType) {
+      var m = key.match(/^-*BEGIN (RSA |DSA )?PUBLIC KEY-*/);
+      if (m && m.length == 2 && m[1])
+        keyType = m[1];
+      else if (m && m.length == 2)
+        keyType = 'rsa';
+      else
+        keyType = 'hmac';
+    }
 
     var alg = parsedSignature.algorithm.match(/(HMAC|RSA|DSA)-(\w+)/);
     if (!alg || alg.length !== 3)
       throw new TypeError('parsedSignature: unsupported algorithm ' +
+                          parsedSignature.algorithm);
+
+    if (alg[1] !== keyType.toUpperCase())
+      throw new TypeError('key type does not match signature algorithm ' +
                           parsedSignature.algorithm);
 
     if (alg[1] === 'HMAC') {


### PR DESCRIPTION
See also #40 

If verifySignature is not given the optional keyType argument, we auto-detect by looking at the start of the given key. This provides backwards compatibility.