### PR TITLE
add draft 03 compliance, plus tests for same

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -30,6 +30,7 @@ var ParamsState = {
 };
 
 var Drafts = {
+  '04' : '(request-target)',
   '03' : '(request-target)',
   '01' : 'request-line' 
 };
@@ -278,7 +279,7 @@ module.exports = {
           parsed.signingString +=
             request.method + ' ' + request.url + ' HTTP/' + request.httpVersion;
         else 
-          parsed.signingString += h + ': ' + request.method + ' ' + request.url;
+          parsed.signingString += h + ': ' + request.method.toLowerCase() + ' ' + request.url;
       }
 
       if ((i + 1) < parsed.params.headers.length)

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -29,6 +29,11 @@ var ParamsState = {
   Comma: 3
 };
 
+var Drafts = {
+  '03' : '(target-request)',
+  '01' : 'request-line' 
+};
+
 
 
 ///--- Specific Errors
@@ -66,6 +71,11 @@ function MissingHeaderError(message) {
 util.inherits(MissingHeaderError, HttpSignatureError);
 
 
+function InvalidDraftError(message) {
+  HttpSignatureError.call(this, message, InvalidDraftError);
+}
+util.inherits(InvalidDraftError, HttpSignatureError);
+
 
 ///--- Exported API
 
@@ -100,6 +110,7 @@ module.exports = {
    *                   - clockSkew: allowed clock skew in seconds (default 300).
    *                   - headers: required header names (def: date or x-date)
    *                   - algorithms: algorithms to support (default: all).
+   *                   - {String} draft: draft to support (default: '01').
    * @return {Object} parsed out object (see above).
    * @throws {TypeError} on invalid input.
    * @throws {InvalidHeaderError} on an invalid Authorization header error.
@@ -122,19 +133,24 @@ module.exports = {
     assert.object(options, 'options');
     assert.arrayOfString(options.headers, 'options.headers');
     assert.optionalNumber(options.clockSkew, 'options.clockSkew');
+    assert.optionalString(options.draft, 'options.draft');
 
     if (!request.headers.authorization)
       throw new MissingHeaderError('no authorization header present in ' +
                                    'the request');
 
     options.clockSkew = options.clockSkew || 300;
+    options.draft = options.draft || '01';
 
+    if (!Drafts[options.draft])
+      throw new InvalidDraftError(options.draft + ' is not supported');
 
     var i = 0;
     var state = State.New;
     var substate = ParamsState.Name;
     var tmpName = '';
     var tmpValue = '';
+    var specialHeader = Drafts[options.draft];
 
     var parsed = {
       scheme: '',
@@ -252,14 +268,17 @@ module.exports = {
       var h = parsed.params.headers[i].toLowerCase();
       parsed.params.headers[i] = h;
 
-      if (h !== 'request-line') {
+      if (h !== specialHeader) {
         var value = request.headers[h];
         if (!value)
           throw new MissingHeaderError(h + ' was not in the request');
         parsed.signingString += h + ': ' + value;
       } else {
-        parsed.signingString +=
-          request.method + ' ' + request.url + ' HTTP/' + request.httpVersion;
+        if (options.draft === '01')
+          parsed.signingString +=
+            request.method + ' ' + request.url + ' HTTP/' + request.httpVersion;
+        else 
+          parsed.signingString += h + ': ' + request.method + ' ' + request.url;
       }
 
       if ((i + 1) < parsed.params.headers.length)

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -30,7 +30,7 @@ var ParamsState = {
 };
 
 var Drafts = {
-  '03' : '(target-request)',
+  '03' : '(request-target)',
   '01' : 'request-line' 
 };
 

--- a/lib/signer.js
+++ b/lib/signer.js
@@ -24,7 +24,7 @@ var Authorization =
   'Signature keyId="%s",algorithm="%s",headers="%s",signature="%s"';
 
 var Drafts = {
-  '03' : '(target-request)',
+  '03' : '(request-target)',
   '01' : 'request-line' 
 };
 

--- a/lib/signer.js
+++ b/lib/signer.js
@@ -20,13 +20,25 @@ var Algorithms = {
   'hmac-sha512': true
 };
 
-var Authorization =
-  'Signature keyId="%s",algorithm="%s",headers="%s",signature="%s"';
+var DraftOptions = {
+      '04' : { 
+        specialHeader: '(request-target)',
+        sigHeaderTemplate: 'keyId="%s",algorithm="%s",headers="%s",signature="%s"',
+        sigHeaderName : 'Signature'
+      },
 
-var Drafts = {
-  '03' : '(request-target)',
-  '01' : 'request-line' 
-};
+      '03' : { 
+        specialHeader: '(request-target)',
+        sigHeaderTemplate: 'keyId="%s",algorithm="%s",headers="%s",signature="%s"',
+        sigHeaderName : 'Signature'
+      },
+
+      '01' : { 
+        specialHeader: 'request-line', 
+        sigHeaderTemplate: 'Signature keyId="%s",algorithm="%s",headers="%s",signature="%s"',
+        sigHeaderName : 'Authorization'
+      }
+    };
 
 
 
@@ -144,7 +156,7 @@ module.exports = {
     if (!options.draft)
       options.draft = '01';
 
-    if (!Drafts[options.draft])
+    if (!DraftOptions[options.draft])
       throw new InvalidDraftError('draft ' + options.draft + ' is not supported');
 
     options.algorithm = options.algorithm.toLowerCase();
@@ -154,7 +166,7 @@ module.exports = {
 
     var i;
     var stringToSign = '';
-    var specialHeader = Drafts[options.draft];
+    var specialHeader = DraftOptions[options.draft].specialHeader;
     for (i = 0; i < options.headers.length; i++) {
       if (typeof (options.headers[i]) !== 'string')
         throw new TypeError('options.headers must be an array of Strings');
@@ -171,8 +183,8 @@ module.exports = {
         if (options.draft === '01')
           stringToSign +=
             request.method + ' ' + request.path + ' HTTP/' + options.httpVersion;
-        else 
-          stringToSign += h + ': ' + request.method + ' ' + request.path;
+        else // all others
+          stringToSign += h + ': ' + request.method.toLowerCase() + ' ' + request.path;
       }
 
       if ((i + 1) < options.headers.length)
@@ -191,12 +203,14 @@ module.exports = {
       signature = signer.sign(options.key, 'base64');
     }
 
-    request.setHeader('Authorization', sprintf(Authorization,
+    var sigHeader = DraftOptions[options.draft].sigHeaderName, 
+        hdrTemplate = DraftOptions[options.draft].sigHeaderTemplate;
+
+    request.setHeader(sigHeader, sprintf(hdrTemplate,
                                                options.keyId,
                                                options.algorithm,
                                                options.headers.join(' '),
                                                signature));
-
     return true;
   }
 

--- a/lib/signer.js
+++ b/lib/signer.js
@@ -23,6 +23,11 @@ var Algorithms = {
 var Authorization =
   'Signature keyId="%s",algorithm="%s",headers="%s",signature="%s"';
 
+var Drafts = {
+  '03' : '(target-request)',
+  '01' : 'request-line' 
+};
+
 
 
 ///--- Specific Errors
@@ -41,6 +46,13 @@ function InvalidAlgorithmError(message) {
     this.stack = (new Error()).stack;
 }
 InvalidAlgorithmError.prototype = new Error();
+
+function InvalidDraftError(message) {
+    this.name = 'InvalidDraftError';
+    this.message = message;
+    this.stack = (new Error()).stack;
+}
+InvalidDraftError.prototype = new Error();
 
 
 
@@ -103,9 +115,11 @@ module.exports = {
    *                   - {Array} headers optional; defaults to ['date'].
    *                   - {String} algorithm optional; defaults to 'rsa-sha256'.
    *                   - {String} httpVersion optional; defaults to '1.1'.
+   *                   - {String} draft optional; '03' or '01', defaults to '01'.
    * @return {Boolean} true if Authorization (and optionally Date) were added.
    * @throws {TypeError} on bad parameter types (input).
    * @throws {InvalidAlgorithmError} if algorithm was bad.
+   * @throws {InvalidDraftError} if draft was bad.
    * @throws {MissingHeaderError} if a header to be signed was specified but
    *                              was not present.
    */
@@ -116,6 +130,7 @@ module.exports = {
     assert.string(options.keyId, 'options.keyId');
     assert.optionalArrayOfString(options.headers, 'options.headers');
     assert.optionalString(options.httpVersion, 'options.httpVersion');
+    assert.optionalString(options.draft, 'options.draft');
 
     if (!request.getHeader('Date'))
       request.setHeader('Date', _rfc1123());
@@ -126,6 +141,12 @@ module.exports = {
     if (!options.httpVersion)
       options.httpVersion = '1.1';
 
+    if (!options.draft)
+      options.draft = '01';
+
+    if (!Drafts[options.draft])
+      throw new InvalidDraftError('draft ' + options.draft + ' is not supported');
+
     options.algorithm = options.algorithm.toLowerCase();
 
     if (!Algorithms[options.algorithm])
@@ -133,21 +154,25 @@ module.exports = {
 
     var i;
     var stringToSign = '';
+    var specialHeader = Drafts[options.draft];
     for (i = 0; i < options.headers.length; i++) {
       if (typeof (options.headers[i]) !== 'string')
         throw new TypeError('options.headers must be an array of Strings');
 
       var h = options.headers[i].toLowerCase();
 
-      if (h !== 'request-line') {
+      if (h !== specialHeader) {
         var value = request.getHeader(h);
         if (!value) {
           throw new MissingHeaderError(h + ' was not in the request');
         }
         stringToSign += h + ': ' + value;
       } else {
-        stringToSign +=
-          request.method + ' ' + request.path + ' HTTP/' + options.httpVersion;
+        if (options.draft === '01')
+          stringToSign +=
+            request.method + ' ' + request.path + ' HTTP/' + options.httpVersion;
+        else 
+          stringToSign += h + ': ' + request.method + ' ' + request.path;
       }
 
       if ((i + 1) < options.headers.length)


### PR DESCRIPTION
This PR modifies signer.js and parser.js to comply with the draft 03 spec, regarding (target-request) vs request-line . 