### PR TITLE
Use sshpk library for fingerprints and key conversions

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -1,187 +1,7 @@
 // Copyright 2012 Joyent, Inc.  All rights reserved.
 
 var assert = require('assert-plus');
-var crypto = require('crypto');
-
-var asn1 = require('asn1');
-var ctype = require('ctype');
-
-
-
-///--- Helpers
-
-function readNext(buffer, offset) {
-  var len = ctype.ruint32(buffer, 'big', offset);
-  offset += 4;
-
-  var newOffset = offset + len;
-
-  return {
-    data: buffer.slice(offset, newOffset),
-    offset: newOffset
-  };
-}
-
-
-function writeInt(writer, buffer) {
-  writer.writeByte(0x02); // ASN1.Integer
-  writer.writeLength(buffer.length);
-
-  for (var i = 0; i < buffer.length; i++)
-    writer.writeByte(buffer[i]);
-
-  return writer;
-}
-
-
-function rsaToPEM(key) {
-  var buffer;
-  var der;
-  var exponent;
-  var i;
-  var modulus;
-  var newKey = '';
-  var offset = 0;
-  var type;
-  var tmp;
-
-  try {
-    buffer = new Buffer(key.split(' ')[1], 'base64');
-
-    tmp = readNext(buffer, offset);
-    type = tmp.data.toString();
-    offset = tmp.offset;
-
-    if (type !== 'ssh-rsa')
-      throw new Error('Invalid ssh key type: ' + type);
-
-    tmp = readNext(buffer, offset);
-    exponent = tmp.data;
-    offset = tmp.offset;
-
-    tmp = readNext(buffer, offset);
-    modulus = tmp.data;
-  } catch (e) {
-    throw new Error('Invalid ssh key: ' + key);
-  }
-
-  // DER is a subset of BER
-  der = new asn1.BerWriter();
-
-  der.startSequence();
-
-  der.startSequence();
-  der.writeOID('1.2.840.113549.1.1.1');
-  der.writeNull();
-  der.endSequence();
-
-  der.startSequence(0x03); // bit string
-  der.writeByte(0x00);
-
-  // Actual key
-  der.startSequence();
-  writeInt(der, modulus);
-  writeInt(der, exponent);
-  der.endSequence();
-
-  // bit string
-  der.endSequence();
-
-  der.endSequence();
-
-  tmp = der.buffer.toString('base64');
-  for (i = 0; i < tmp.length; i++) {
-    if ((i % 64) === 0)
-      newKey += '\n';
-    newKey += tmp.charAt(i);
-  }
-
-  if (!/\\n$/.test(newKey))
-    newKey += '\n';
-
-  return '-----BEGIN PUBLIC KEY-----' + newKey + '-----END PUBLIC KEY-----\n';
-}
-
-
-function dsaToPEM(key) {
-  var buffer;
-  var offset = 0;
-  var tmp;
-  var der;
-  var newKey = '';
-
-  var type;
-  var p;
-  var q;
-  var g;
-  var y;
-
-  try {
-    buffer = new Buffer(key.split(' ')[1], 'base64');
-
-    tmp = readNext(buffer, offset);
-    type = tmp.data.toString();
-    offset = tmp.offset;
-
-    /* JSSTYLED */
-    if (!/^ssh-ds[as].*/.test(type))
-      throw new Error('Invalid ssh key type: ' + type);
-
-    tmp = readNext(buffer, offset);
-    p = tmp.data;
-    offset = tmp.offset;
-
-    tmp = readNext(buffer, offset);
-    q = tmp.data;
-    offset = tmp.offset;
-
-    tmp = readNext(buffer, offset);
-    g = tmp.data;
-    offset = tmp.offset;
-
-    tmp = readNext(buffer, offset);
-    y = tmp.data;
-  } catch (e) {
-    console.log(e.stack);
-    throw new Error('Invalid ssh key: ' + key);
-  }
-
-  // DER is a subset of BER
-  der = new asn1.BerWriter();
-
-  der.startSequence();
-
-  der.startSequence();
-  der.writeOID('1.2.840.10040.4.1');
-
-  der.startSequence();
-  writeInt(der, p);
-  writeInt(der, q);
-  writeInt(der, g);
-  der.endSequence();
-
-  der.endSequence();
-
-  der.startSequence(0x03); // bit string
-  der.writeByte(0x00);
-  writeInt(der, y);
-  der.endSequence();
-
-  der.endSequence();
-
-  tmp = der.buffer.toString('base64');
-  for (var i = 0; i < tmp.length; i++) {
-    if ((i % 64) === 0)
-      newKey += '\n';
-    newKey += tmp.charAt(i);
-  }
-
-  if (!/\\n$/.test(newKey))
-    newKey += '\n';
-
-  return '-----BEGIN PUBLIC KEY-----' + newKey + '-----END PUBLIC KEY-----\n';
-}
-
+var sshpk = require('sshpk');
 
 ///--- API
 
@@ -201,15 +21,8 @@ module.exports = {
   sshKeyToPEM: function sshKeyToPEM(key) {
     assert.string(key, 'ssh_key');
 
-    /* JSSTYLED */
-    if (/^ssh-rsa.*/.test(key))
-      return rsaToPEM(key);
-
-    /* JSSTYLED */
-    if (/^ssh-ds[as].*/.test(key))
-      return dsaToPEM(key);
-
-    throw new Error('Only RSA and DSA public keys are allowed');
+    var k = sshpk.parseKey(key, 'ssh');
+    return (k.toString('pem'));
   },
 
 
@@ -224,25 +37,8 @@ module.exports = {
   fingerprint: function fingerprint(key) {
     assert.string(key, 'ssh_key');
 
-    var pieces = key.split(' ');
-    if (!pieces || !pieces.length || pieces.length < 2)
-      throw new Error('invalid ssh key');
-
-    var data = new Buffer(pieces[1], 'base64');
-
-    var hash = crypto.createHash('md5');
-    hash.update(data);
-    var digest = hash.digest('hex');
-
-    var fp = '';
-    for (var i = 0; i < digest.length; i++) {
-      if (i && i % 2 === 0)
-        fp += ':';
-
-      fp += digest[i];
-    }
-
-    return fp;
+    var k = sshpk.parseKey(key, 'ssh');
+    return (k.fingerprint('md5').toString('hex'));
   },
 
   /**
@@ -253,54 +49,8 @@ module.exports = {
   pemToRsaSSHKey: function pemToRsaSSHKey(pem, comment) {
     assert.equal('string', typeof (pem), 'typeof pem');
 
-    // chop off the BEGIN PUBLIC KEY and END PUBLIC KEY portion
-    var cleaned = pem.split('\n').slice(1, -2).join('');
-
-    var buf = new Buffer(cleaned, 'base64');
-
-    var der = new asn1.BerReader(buf);
-
-    der.readSequence();
-    der.readSequence();
-
-    var oid = der.readOID();
-    assert.equal(oid, '1.2.840.113549.1.1.1', 'pem not in RSA format');
-
-    // Null -- XXX this probably isn't good practice
-    der.readByte();
-    der.readByte();
-
-    // bit string sequence
-    der.readSequence(0x03);
-    der.readByte();
-    der.readSequence();
-
-    // modulus
-    assert.equal(der.peek(), asn1.Ber.Integer, 'modulus not an integer');
-    der._offset = der.readLength(der.offset + 1);
-    var modulus = der._buf.slice(der.offset, der.offset + der.length);
-    der._offset += der.length;
-
-    // exponent
-    assert.equal(der.peek(), asn1.Ber.Integer, 'exponent not an integer');
-    der._offset = der.readLength(der.offset + 1);
-    var exponent = der._buf.slice(der.offset, der.offset + der.length);
-    der._offset += der.length;
-
-    // now, make the key
-    var type = new Buffer('ssh-rsa');
-    var buffer = new Buffer(4 + type.length + 4 + modulus.length +
-      4 + exponent.length);
-    var i = 0;
-    buffer.writeUInt32BE(type.length, i);     i += 4;
-    type.copy(buffer, i);                     i += type.length;
-    buffer.writeUInt32BE(exponent.length, i); i += 4;
-    exponent.copy(buffer, i);                 i += exponent.length;
-    buffer.writeUInt32BE(modulus.length, i);  i += 4;
-    modulus.copy(buffer, i);                  i += modulus.length;
-
-    var s = (type.toString() + ' ' + buffer.toString('base64') + ' ' +
-      (comment || ''));
-    return s;
+    var k = sshpk.parseKey(pem, 'pem');
+    k.comment = comment;
+    return (k.toString('ssh'));
   }
 };

--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
   },
   "dependencies": {
     "assert-plus": "^0.1.5",
-    "asn1": "0.1.11",
-    "ctype": "0.5.3"
+    "sshpk": "~1.0"
   },
   "devDependencies": {
     "node-uuid": "^1.4.1",


### PR DESCRIPTION
As part of PUBAPI-1146 I'm trying to centralize all the code that deals with SSH key fingerprints and format conversions, and `http-signature` currently includes a reimplementation of both of these, which are widely used by other libraries and apps.

This PR changes http-signature to use the `sshpk` library instead for these tasks, which has the centralized version of all this code. It maintains full API compatibility.

I'm leaving the tests for this code in place, even though they are entirely covered by the tests already in `sshpk` itself, as they do test here that backwards compat is retained for apps using this functions from under `http-signature`'s namespace.