### PR TITLE
Allow signature format as an optional parameter in signRequest

### DIFF
--- a/lib/signer.js
+++ b/lib/signer.js
@@ -20,7 +20,7 @@ var Algorithms = {
   'hmac-sha512': true
 };
 
-var Authorization =
+var StandardSignatureStringFormat =
   'Signature keyId="%s",algorithm="%s",headers="%s",signature="%s"';
 
 
@@ -125,6 +125,8 @@ module.exports = {
       options.algorithm = 'rsa-sha256';
     if (!options.httpVersion)
       options.httpVersion = '1.1';
+    if (!options.signatureFormat)
+	options.signatureFormat = StandardSignatureStringFormat;
 
     options.algorithm = options.algorithm.toLowerCase();
 
@@ -167,7 +169,7 @@ module.exports = {
       assert.notStrictEqual(signature, '', 'empty signature produced');
     }
 
-    request.setHeader('Authorization', sprintf(Authorization,
+    request.setHeader('Authorization', sprintf(options.signatureFormat,
                                                options.keyId,
                                                options.algorithm,
                                                options.headers.join(' '),


### PR DESCRIPTION
Hard coding the signature format often restricts the use case to strictly complaint sever implementations only.

We allow an optional signature format to be specified (with a fallback to standard format) which will enable uses cases where server side implementations are not strictly complaint.