### PR TITLE
migrate to assert-plus@0.2.0 as it contains license informations

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "tap test/*.js"
   },
   "dependencies": {
-    "assert-plus": "^0.1.5",
+    "assert-plus": "^0.2.0",
     "jsprim": "^1.2.2",
     "sshpk": "^1.7.0"
   },


### PR DESCRIPTION
Hey there. The old version of assert-plus did not contain any license information.
For a project of mine it is necessary, that I can retrieve license informations of all dependencies I use.

Would you mind merging this PR and publish a new version of http-signature?

Thanks