### PR TITLE
Add ability to pass a custom sign function to signRequest

### DIFF
--- a/lib/signer.js
+++ b/lib/signer.js
@@ -260,6 +260,11 @@ module.exports = {
    * You shouldn't need to check the return type; it's just there if you want
    * to be pedantic.
    *
+   * A custom signing function may be passed in through the options.sign
+   * parameter. If specified, signRequest MUST be given a callback,
+   * and options.algorithm must be given as it cannot be inferred from
+   * the sign function.
+   *
    * The optional flag indicates whether parsing should use strict enforcement
    * of the version draft-cavage-http-signatures-04 of the spec or beyond.
    * The default is to be loose and support
@@ -268,14 +273,23 @@ module.exports = {
    * @param {Object} request an instance of http.ClientRequest.
    * @param {Object} options signing parameters object:
    *                   - {String} keyId required.
-   *                   - {String} key required (either a PEM or HMAC key).
+   *                   - {String} key required (either a PEM or HMAC key),
+   *                              unless a sign function is explicitly passed.
    *                   - {Array} headers optional; defaults to ['date'].
-   *                   - {String} algorithm optional (unless key is HMAC);
+   *                   - {String} algorithm optional (unless key is HMAC or a
+   *                              sign function is specified);
    *                              default is the same as the sshpk default
    *                              signing algorithm for the type of key given
    *                   - {String} httpVersion optional; defaults to '1.1'.
+   *                   - {Func} sign optional;
+   *                            a custom signing function with the parameter
+   *                            (dataToSign, options, callback(err, signature))
    *                   - {Boolean} strict optional; defaults to 'false'.
+   * @param {Func} callback an asynchronous callback(err, result). signRequest
+   *               will execute synchronously if callback is not passed.
+   *               callback is required if options.sign is specified.
    * @return {Boolean} true if Authorization (and optionally Date) were added.
+   *                   Returned through callback result if callback specified.
    * @throws {TypeError} on bad parameter types (input).
    * @throws {InvalidAlgorithmError} if algorithm was bad or incompatible with
    *                                 the given key.
@@ -283,13 +297,26 @@ module.exports = {
    * @throws {MissingHeaderError} if a header to be signed was specified but
    *                              was not present.
    */
-  signRequest: function signRequest(request, options) {
+  signRequest: function signRequest(request, options, callback) {
     assert.object(request, 'request');
     assert.object(options, 'options');
     assert.optionalString(options.algorithm, 'options.algorithm');
     assert.string(options.keyId, 'options.keyId');
     assert.optionalArrayOfString(options.headers, 'options.headers');
     assert.optionalString(options.httpVersion, 'options.httpVersion');
+    assert.optionalFunc(options.sign, 'options.sign');
+    assert.optionalFunc(callback, 'callback');
+
+    if (options.sign) {
+      if (!callback) {
+        throw (new TypeError('A callback must be passed in if ' +
+          'options.sign is specified'));
+      }
+      if (!options.algorithm) {
+        return callback(new TypeError('options.algorithm must be ' +
+          'passed in if options.sign is specified'), false);
+      }
+    }
 
     if (!request.getHeader('Date'))
       request.setHeader('Date', jsprim.rfc1123(new Date()));
@@ -347,6 +374,11 @@ module.exports = {
       request._stringToSign = stringToSign;
     }
 
+    if (options.sign) {
+      /* Use the passed in signing function to sign the signature. */
+      return options.sign(stringToSign, options, addSignatureHeader)
+    }
+
     var signature;
     if (alg[0] === 'hmac') {
       if (typeof (options.key) !== 'string' && !Buffer.isBuffer(options.key))
@@ -387,13 +419,27 @@ module.exports = {
       assert.notStrictEqual(signature, '', 'empty signature produced');
     }
 
-    request.setHeader('Authorization', sprintf(AUTHZ_FMT,
+    addSignatureHeader(null, signature);
+
+    return true;
+
+    function addSignatureHeader(err, signature) {
+      if (callback && err) {
+        return process.nextTick(function() {
+          callback(err, false);
+        });
+      }
+      request.setHeader('Authorization', sprintf(AUTHZ_FMT,
                                                options.keyId,
                                                options.algorithm,
                                                options.headers.join(' '),
                                                signature));
-
-    return true;
+      if (callback) {
+        process.nextTick(function() {
+          callback(null, true);
+        });
+      }
+    }
   }
 
 };


### PR DESCRIPTION
This lets you explicitly specify how to sign a signRequest signature string via a passed in function. Useful if you would like to use an arbitrary signing method with the signRequest API -- one specific use case being the offloading of sign requests to an SSM or HSM (keeping private key data secure), instead of having to pass the private key explicitly into the signRequest function.

Because this was designed to be able to sign things off-process (like with an HSM), the passed in function is asynchronous, meaning a callback function must be passed in to signRequest if a signing function is specified. This new functionality does not have any effect on existing API.