### PR TITLE
Avoid using deprecated Buffer API on newer Node.js

### DIFF
--- a/lib/verify.js
+++ b/lib/verify.js
@@ -73,7 +73,22 @@ module.exports = {
     h1.update(hmac.digest());
     h1 = h1.digest();
     var h2 = crypto.createHmac(hashAlg, secret);
-    h2.update(new Buffer(parsedSignature.params.signature, 'base64'));
+
+    var signatureBase64 = parsedSignature.params.signature;
+    var signatureBuffer;
+    if (Buffer.from && Buffer.from !== Uint8Array.from) {
+      // Node.js 4.5.0 and newer
+      signatureBuffer = Buffer.from(signatureBase64, 'base64');
+    } else {
+      // Node.js <4.5.0 || >=5.0.0 <5.10.0
+      if (typeof signatureBase64 === 'number') {
+        // type-guard against uninitentional uninitialized Buffer allocation
+        throw new Error('Unexpected .signature type: number, string expected');
+      }
+      signatureBuffer = new Buffer(signatureBase64, 'base64');
+    }
+    h2.update(signatureBuffer);
+
     h2 = h2.digest();
 
     /* Node 0.8 returns strings from .digest(). */


### PR DESCRIPTION
This avoids using Buffer constructor API on newer Node.js versions.

To achieve that, `Buffer.from` presence is checked, with validation that it's not the same method as Uint8Array.from.

Also an additional type-guard is added in the fallback code path to ensure that typed numbers are never accidently fed into `new Buffer` input.

Given this module popularity and the fact that old Buffer constructor API was used in a single place, I decided to just feature-detect it in-place instead of pulling in polyfill deps.
Another way would be to just use `Buffer.from` and do `var Buffer = require('safe-buffer')`;

Refs:
https://nodejs.org/api/deprecations.html#deprecations_dep0005_buffer_constructor
Tracking:
https://github.com/nodejs/node/issues/19079