### PR TITLE
snyk security vuln. - update sshpk version

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "assert-plus": "^1.0.0",
     "jsprim": "^1.2.2",
-    "sshpk": "^1.7.0"
+    "sshpk": "^1.14.1"
   },
   "devDependencies": {
     "tap": "0.4.2",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "assert-plus": "^1.0.0",
     "jsprim": "^1.2.2",
-    "sshpk": "^1.14.1"
+    "sshpk": "^1.14.2"
   },
   "devDependencies": {
     "tap": "0.4.2",


### PR DESCRIPTION
✗ High severity vulnerability found on sshpk@1.13.1
- desc: Regular Expression Denial of Service (ReDoS)
- info: https://snyk.io/vuln/npm:sshpk:20180409
- from: node_services@1.0.0 > node-gyp@3.6.2 > request@2.83.0 > http-signature@1.2.0 > sshpk@1.13.1
Your dependencies are out of date, otherwise you would be using a newer sshpk than sshpk@1.13.1.