### PR TITLE
bump version of sshpk to 1.14.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "http-signature",
   "description": "Reference implementation of Joyent's HTTP Signature scheme.",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "license": "MIT",
   "author": "Joyent, Inc",
   "contributors": [
@@ -30,10 +30,10 @@
   "dependencies": {
     "assert-plus": "^1.0.0",
     "jsprim": "^1.2.2",
-    "sshpk": "^1.7.0"
+    "sshpk": "~1.14.1"
   },
   "devDependencies": {
-    "tap": "0.4.2",
+    "tap": "~12.0.1",
     "uuid": "^2.0.2"
   }
 }


### PR DESCRIPTION
Upgrade sshpk to 1.14.1 as per the advisory listed here at - 
https://nodesecurity.io/advisories/606

