### PR TITLE
Add Signature header support.

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -26,6 +26,8 @@ var ParamsState = {
   Comma: 3
 };
 
+var authorizationHeaderName = 'authorization';
+var sigHeaderName = 'signature';
 
 ///--- Specific Errors
 
@@ -118,91 +120,93 @@ module.exports = {
     assert.arrayOfString(options.headers, 'options.headers');
     assert.optionalFinite(options.clockSkew, 'options.clockSkew');
 
-    var authzHeaderName = options.authorizationHeaderName || 'authorization';
+    var headers = request.headers;
+    var authzHeaderName = options.authorizationHeaderName;
+    var authz = headers[authzHeaderName] || headers[authorizationHeaderName] || headers[sigHeaderName];
 
-    if (!request.headers[authzHeaderName]) {
-      throw new MissingHeaderError('no ' + authzHeaderName + ' header ' +
-                                   'present in the request');
+    if (!authz) {
+      var errHeader = authzHeaderName ? authzHeaderName : 'authorization or signature';
+      throw new MissingHeaderError('no ' + errHeader + ' header ' +
+        'present in the request');
     }
 
     options.clockSkew = options.clockSkew || 300;
 
 
     var i = 0;
-    var state = State.New;
+    var state = authz === headers[sigHeaderName] ? State.Params : State.New;
     var substate = ParamsState.Name;
     var tmpName = '';
     var tmpValue = '';
 
     var parsed = {
-      scheme: '',
+      scheme: authz === headers[sigHeaderName] ? 'Signature' : '',
       params: {},
       signingString: ''
     };
 
-    var authz = request.headers[authzHeaderName];
     for (i = 0; i < authz.length; i++) {
       var c = authz.charAt(i);
 
       switch (Number(state)) {
 
-      case State.New:
-        if (c !== ' ') parsed.scheme += c;
-        else state = State.Params;
-        break;
-
-      case State.Params:
-        switch (Number(substate)) {
-
-        case ParamsState.Name:
-          var code = c.charCodeAt(0);
-          // restricted name of A-Z / a-z
-          if ((code >= 0x41 && code <= 0x5a) || // A-Z
-              (code >= 0x61 && code <= 0x7a)) { // a-z
-            tmpName += c;
-          } else if (c === '=') {
-            if (tmpName.length === 0)
-              throw new InvalidHeaderError('bad param format');
-            substate = ParamsState.Quote;
-          } else {
-            throw new InvalidHeaderError('bad param format');
-          }
+        case State.New:
+          if (c !== ' ') parsed.scheme += c;
+          else state = State.Params;
           break;
 
-        case ParamsState.Quote:
-          if (c === '"') {
-            tmpValue = '';
-            substate = ParamsState.Value;
-          } else {
-            throw new InvalidHeaderError('bad param format');
-          }
-          break;
+        case State.Params:
+          switch (Number(substate)) {
 
-        case ParamsState.Value:
-          if (c === '"') {
-            parsed.params[tmpName] = tmpValue;
-            substate = ParamsState.Comma;
-          } else {
-            tmpValue += c;
-          }
-          break;
+            case ParamsState.Name:
+              var code = c.charCodeAt(0);
+              // restricted name of A-Z / a-z
+              if ((code >= 0x41 && code <= 0x5a) || // A-Z
+                (code >= 0x61 && code <= 0x7a)) { // a-z
+                tmpName += c;
+              } else if (c === '=') {
+                if (tmpName.length === 0)
+                  throw new InvalidHeaderError('bad param format');
+                substate = ParamsState.Quote;
+              } else {
+                throw new InvalidHeaderError('bad param format');
+              }
+              break;
 
-        case ParamsState.Comma:
-          if (c === ',') {
-            tmpName = '';
-            substate = ParamsState.Name;
-          } else {
-            throw new InvalidHeaderError('bad param format');
+            case ParamsState.Quote:
+              if (c === '"') {
+                tmpValue = '';
+                substate = ParamsState.Value;
+              } else {
+                throw new InvalidHeaderError('bad param format');
+              }
+              break;
+
+            case ParamsState.Value:
+              if (c === '"') {
+                parsed.params[tmpName] = tmpValue;
+                substate = ParamsState.Comma;
+              } else {
+                tmpValue += c;
+              }
+              break;
+
+            case ParamsState.Comma:
+              if (c === ',') {
+                tmpName = '';
+                substate = ParamsState.Name;
+              } else {
+                throw new InvalidHeaderError('bad param format');
+              }
+              break;
+
+            default:
+              throw new Error('Invalid substate');
           }
           break;
 
         default:
           throw new Error('Invalid substate');
-        }
-        break;
-
-      default:
-        throw new Error('Invalid substate');
       }
 
     }
@@ -278,19 +282,19 @@ module.exports = {
     // Check against the constraints
     var date;
     if (request.headers.date || request.headers['x-date']) {
-        if (request.headers['x-date']) {
-          date = new Date(request.headers['x-date']);
-        } else {
-          date = new Date(request.headers.date);
-        }
+      if (request.headers['x-date']) {
+        date = new Date(request.headers['x-date']);
+      } else {
+        date = new Date(request.headers.date);
+      }
       var now = new Date();
       var skew = Math.abs(now.getTime() - date.getTime());
 
       if (skew > options.clockSkew * 1000) {
         throw new ExpiredRequestError('clock skew of ' +
-                                      (skew / 1000) +
-                                      's was greater than ' +
-                                      options.clockSkew + 's');
+          (skew / 1000) +
+          's was greater than ' +
+          options.clockSkew + 's');
       }
     }
 
@@ -304,7 +308,7 @@ module.exports = {
     if (options.algorithms) {
       if (options.algorithms.indexOf(parsed.params.algorithm) === -1)
         throw new InvalidParamsError(parsed.params.algorithm +
-                                     ' is not a supported algorithm');
+          ' is not a supported algorithm');
     }
 
     parsed.algorithm = parsed.params.algorithm.toUpperCase();

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -26,9 +26,6 @@ var ParamsState = {
   Comma: 3
 };
 
-var authorizationHeaderName = 'authorization';
-var sigHeaderName = 'signature';
-
 ///--- Specific Errors
 
 
@@ -122,10 +119,11 @@ module.exports = {
 
     var headers = request.headers;
     var authzHeaderName = options.authorizationHeaderName;
-    var authz = headers[authzHeaderName] || headers[authorizationHeaderName] || headers[sigHeaderName];
+    var authz = headers[authzHeaderName] || headers[utils.HEADER.AUTH] || headers[utils.HEADER.SIG];
 
     if (!authz) {
-      var errHeader = authzHeaderName ? authzHeaderName : 'authorization or signature';
+      var errHeader = authzHeaderName ? authzHeaderName : utils.HEADER.AUTH + ' or ' + utils.HEADER.SIG;
+
       throw new MissingHeaderError('no ' + errHeader + ' header ' +
         'present in the request');
     }

--- a/lib/signer.js
+++ b/lib/signer.js
@@ -20,6 +20,8 @@ var validateAlgorithm = utils.validateAlgorithm;
 var AUTHZ_FMT =
   'Signature keyId="%s",algorithm="%s",headers="%s",signature="%s"';
 
+var SIGNATURE_FMT = 'keyId="%s",algorithm="%s",headers="%s",signature="%s"';
+
 ///--- Specific Errors
 
 function MissingHeaderError(message) {
@@ -388,7 +390,8 @@ module.exports = {
 
     var authzHeaderName = options.authorizationHeaderName || 'Authorization';
 
-    request.setHeader(authzHeaderName, sprintf(AUTHZ_FMT,
+    var FMT = authzHeaderName.toLowerCase() === utils.HEADER.SIG ? SIGNATURE_FMT : AUTHZ_FMT;
+    request.setHeader(authzHeaderName, sprintf(FMT,
       options.keyId,
       options.algorithm,
       options.headers.join(' '),

--- a/lib/signer.js
+++ b/lib/signer.js
@@ -2,7 +2,6 @@
 
 var assert = require('assert-plus');
 var crypto = require('crypto');
-var http = require('http');
 var util = require('util');
 var sshpk = require('sshpk');
 var jsprim = require('jsprim');
@@ -390,10 +389,10 @@ module.exports = {
     var authzHeaderName = options.authorizationHeaderName || 'Authorization';
 
     request.setHeader(authzHeaderName, sprintf(AUTHZ_FMT,
-                                               options.keyId,
-                                               options.algorithm,
-                                               options.headers.join(' '),
-                                               signature));
+      options.keyId,
+      options.algorithm,
+      options.headers.join(' '),
+      signature));
 
     return true;
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -16,6 +16,11 @@ var PK_ALGOS = {
   'ecdsa': true
 };
 
+var HEADER = {
+  AUTH: 'authorization',
+  SIG: 'signature'
+};
+
 function HttpSignatureError(message, caller) {
   if (Error.captureStackTrace)
     Error.captureStackTrace(this, caller || HttpSignatureError);
@@ -54,6 +59,7 @@ function validateAlgorithm(algorithm) {
 ///--- API
 
 module.exports = {
+  HEADER,
 
   HASH_ALGOS: HASH_ALGOS,
   PK_ALGOS: PK_ALGOS,


### PR DESCRIPTION
As specification said, It also support header named `Signature` and there has no scheme in field value.

> The sender is expected to transmit a header (as defined in RFC 7230, Section 3.2) where the "field-name" is "Signature", and the "field-value" contains one or more "auth-param"s (as defined in RFC 7235, Section 4.1) where the "auth-param" parameters meet the requirements listed in Section 2: The Components of a Signature.
> via: https://tools.ietf.org/id/draft-cavage-http-signatures-10.html#sig-header

Both parser and signer should be update to support `signature` header. I have different logic in `parser.js` and `signer`.   

About sign generator part, we only need to add support for `Signature` header if developer set in options, because the format is different with `Authorization` header.   

While we'll use this module to parser different service http request, we should have max compatibility in parser part. So I will try to get authorizationHeaderName which developer set, then try to get `authorization` header, at last I'll try to get `signature` header. 
