### PR TITLE
Fix bug when writing header to request signer

### DIFF
--- a/lib/signer.js
+++ b/lib/signer.js
@@ -131,7 +131,7 @@ RequestSigner.prototype.writeHeader = function (header, value) {
 
   } else {
     var line = header + ': ' + value;
-    if (this.rs_headers.length > 0)
+    if (this.rs_headers.length > 1)
       line = '\n' + line;
     this.rs_signer.update(line);
   }


### PR DESCRIPTION
A '\n' character was always being added at the beginning of the signing
string causing the validation to fail.