### PR TITLE
Allow for non-string HMAC keys

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@
 
 (nothing yet)
 
+## 1.3.2
+
+- Allow Buffers to be used for verifyHMAC (#98)
+
 ## 1.3.1
 
 - Fix node 0.10 usage (#90)

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -44,14 +44,14 @@ module.exports = {
    * that was returned from `parse()`.
    *
    * @param {Object} parsedSignature the object you got from `parse`.
-   * @param {String} secret HMAC shared secret.
+   * @param {String} or {Buffer} secret HMAC shared secret.
    * @return {Boolean} true if valid, false otherwise.
    * @throws {TypeError} if you pass in bad arguments.
    * @throws {InvalidAlgorithmError}
    */
   verifyHMAC: function verifyHMAC(parsedSignature, secret) {
     assert.object(parsedSignature, 'parsedHMAC');
-    assert.string(secret, 'secret');
+    assert(typeof (secret) === 'string' || secret instanceof Buffer);
 
     var alg = validateAlgorithm(parsedSignature.algorithm);
     if (alg[0] !== 'hmac')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "http-signature",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "http-signature",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "http-signature",
   "description": "Reference implementation of Joyent's HTTP Signature scheme.",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "license": "MIT",
   "author": "Joyent, Inc",
   "contributors": [


### PR DESCRIPTION
Currently, the `verifyHMAC` function only accepts a string as `secret`. However as far back at least as node v0.10, the crypto hmac function also accepts a Buffer (allowing for keys that are raw binary values). `verifyHMAC` should also allow them