### PR TITLE
Add support for an opaque param in the Authorization header

### DIFF
--- a/http_signing.md
+++ b/http_signing.md
@@ -287,7 +287,7 @@ The Authorization header would be:
 
 <!-- authz -->
 
-    Authorization: Signature keyId="Test",algorithm="rsa-sha256",headers="date",signature="jKyvPcxB4JbmYY4mByyBY7cZfNl4OW9HpFQlG7N4YcJPteKTu4MWCLyk+gIr0wDgqtLWf9NLpMAMimdfsH7FSWGfbMFSrsVTHNTk0rK3usrfFnti1dxsM4jl0kYJCKTGI/UWkqiaxwNiKqGcdlEDrTcUhhsFsOIo8VhddmZTZ8w="
+    Authorization: Signature keyId="Test",algorithm="rsa-sha256",signature="jKyvPcxB4JbmYY4mByyBY7cZfNl4OW9HpFQlG7N4YcJPteKTu4MWCLyk+gIr0wDgqtLWf9NLpMAMimdfsH7FSWGfbMFSrsVTHNTk0rK3usrfFnti1dxsM4jl0kYJCKTGI/UWkqiaxwNiKqGcdlEDrTcUhhsFsOIo8VhddmZTZ8w="
 
 <!-- /authz -->
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -271,6 +271,11 @@ module.exports = {
         parsed.signingString += '(keyid): ' + parsed.params.keyId;
       } else if (h === '(algorithm)') {
         parsed.signingString += '(algorithm): ' + parsed.params.algorithm;
+      } else if (h === '(opaque)') {
+        var value = parsed.params.opaque;
+        if (value === undefined)
+          throw new MissingHeaderError(h + ' was not in the ' + authzHeaderName + ' header');
+        parsed.signingString += '(opaque): ' + value;
       } else {
         var value = request.headers[h];
         if (value === undefined)
@@ -317,6 +322,7 @@ module.exports = {
 
     parsed.algorithm = parsed.params.algorithm.toUpperCase();
     parsed.keyId = parsed.params.keyId;
+    parsed.opaque = parsed.params.opaque;
     return parsed;
   }
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -117,10 +117,9 @@ module.exports = {
     assert.arrayOfString(options.headers, 'options.headers');
     assert.optionalFinite(options.clockSkew, 'options.clockSkew');
 
-    var headers = request.headers;
     var authzHeaderName = options.authorizationHeaderName;
-    var authz = headers[authzHeaderName] || headers[utils.HEADER.AUTH] ||
-      headers[utils.HEADER.SIG];
+    var authz = request.headers[authzHeaderName] ||
+      request.headers[utils.HEADER.AUTH] || request.headers[utils.HEADER.SIG];
 
     if (!authz) {
       var errHeader = authzHeaderName ? authzHeaderName :
@@ -134,13 +133,14 @@ module.exports = {
 
 
     var i = 0;
-    var state = authz === headers[utils.HEADER.SIG] ? State.Params : State.New;
+    var state = authz === request.headers[utils.HEADER.SIG] ?
+      State.Params : State.New;
     var substate = ParamsState.Name;
     var tmpName = '';
     var tmpValue = '';
 
     var parsed = {
-      scheme: authz === headers[utils.HEADER.SIG] ? 'Signature' : '',
+      scheme: authz === request.headers[utils.HEADER.SIG] ? 'Signature' : '',
       params: {},
       signingString: ''
     };

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -275,8 +275,10 @@ module.exports = {
         parsed.signingString += '(algorithm): ' + parsed.params.algorithm;
       } else if (h === '(opaque)') {
         var opaque = parsed.params.opaque;
-        if (opaque === undefined)
-          throw new MissingHeaderError(h + ' was not in the ' + authzHeaderName + ' header');
+        if (opaque === undefined) {
+          throw new MissingHeaderError('opaque param was not in the ' +
+            authzHeaderName + ' header');
+        }
         parsed.signingString += '(opaque): ' + opaque;
       } else {
         var value = request.headers[h];

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -110,12 +110,14 @@ module.exports = {
     if (options === undefined) {
       options = {};
     }
-    if (options.headers === undefined) {
-      options.headers = [request.headers['x-date'] ? 'x-date' : 'date'];
-    }
     assert.object(options, 'options');
-    assert.arrayOfString(options.headers, 'options.headers');
     assert.optionalFinite(options.clockSkew, 'options.clockSkew');
+
+    var headers = [request.headers['x-date'] ? 'x-date' : 'date'];
+    if (options.headers !== undefined) {
+      assert.arrayOfString(headers, 'options.headers');
+      headers = options.headers;
+    }
 
     var authzHeaderName = options.authorizationHeaderName;
     var authz = request.headers[authzHeaderName] ||
@@ -306,7 +308,7 @@ module.exports = {
       }
     }
 
-    options.headers.forEach(function (hdr) {
+    headers.forEach(function (hdr) {
       // Remember that we already checked any headers in the params
       // were in the request, so if this passes we're good.
       if (parsed.params.headers.indexOf(hdr.toLowerCase()) < 0)

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -272,10 +272,10 @@ module.exports = {
       } else if (h === '(algorithm)') {
         parsed.signingString += '(algorithm): ' + parsed.params.algorithm;
       } else if (h === '(opaque)') {
-        var value = parsed.params.opaque;
-        if (value === undefined)
+        var opaque = parsed.params.opaque;
+        if (opaque === undefined)
           throw new MissingHeaderError(h + ' was not in the ' + authzHeaderName + ' header');
-        parsed.signingString += '(opaque): ' + value;
+        parsed.signingString += '(opaque): ' + opaque;
       } else {
         var value = request.headers[h];
         if (value === undefined)

--- a/lib/signer.js
+++ b/lib/signer.js
@@ -17,10 +17,7 @@ var validateAlgorithm = utils.validateAlgorithm;
 
 ///--- Globals
 
-var AUTHZ_FMT =
-  'Signature keyId="%s",algorithm="%s",headers="%s",signature="%s"';
-
-var SIGNATURE_FMT = 'keyId="%s",algorithm="%s",headers="%s",signature="%s"';
+var AUTHZ_PARAMS = [ 'keyId', 'algorithm', 'headers', 'signature' ];
 
 ///--- Specific Errors
 
@@ -403,15 +400,29 @@ module.exports = {
     }
 
     var authzHeaderName = options.authorizationHeaderName || 'Authorization';
+    var prefix = authzHeaderName.toLowerCase() === utils.HEADER.SIG ?
+      '' : 'Signature ';
 
-    var FMT = authzHeaderName.toLowerCase() === utils.HEADER.SIG ?
-      SIGNATURE_FMT : AUTHZ_FMT;
+    var params = {
+      'keyId': options.keyId,
+      'algorithm': options.algorithm,
+      'signature': signature,
+    };
+    if (options.headers)
+      params.headers = options.headers.join(' ');
 
-    request.setHeader(authzHeaderName, sprintf(FMT,
-      options.keyId,
-      options.algorithm,
-      headers.join(' '),
-      signature));
+    var authz = '';
+    for (i = 0; i < AUTHZ_PARAMS.length; i++) {
+      var key = AUTHZ_PARAMS[i];
+      var value = params[key];
+      if (value === undefined)
+        continue;
+
+      authz += prefix + sprintf('%s="%s"', key, value);
+      prefix = ',';
+    }
+
+    request.setHeader(authzHeaderName, authz);
 
     return true;
   }

--- a/lib/signer.js
+++ b/lib/signer.js
@@ -365,11 +365,11 @@ module.exports = {
       } else if (h === '(algorithm)') {
         stringToSign += '(algorithm): ' + options.algorithm;
       } else if (h === '(opaque)') {
-        var value = options.opaque;
-        if (value == undefined || value === '') {
+        var opaque = options.opaque;
+        if (opaque == undefined || opaque === '') {
           throw new MissingHeaderError('options.opaque was not in the request');
         }
-        stringToSign += '(opaque): ' + value;
+        stringToSign += '(opaque): ' + opaque;
       } else {
         var value = request.getHeader(h);
         if (value === undefined || value === '') {

--- a/lib/signer.js
+++ b/lib/signer.js
@@ -294,8 +294,9 @@ module.exports = {
 
     if (!request.getHeader('Date'))
       request.setHeader('Date', jsprim.rfc1123(new Date()));
-    if (!options.headers)
-      options.headers = ['date'];
+    var headers = ['date'];
+    if (options.headers)
+      headers = options.headers;
     if (!options.httpVersion)
       options.httpVersion = '1.1';
 
@@ -337,11 +338,11 @@ module.exports = {
 
     var i;
     var stringToSign = '';
-    for (i = 0; i < options.headers.length; i++) {
-      if (typeof (options.headers[i]) !== 'string')
+    for (i = 0; i < headers.length; i++) {
+      if (typeof (headers[i]) !== 'string')
         throw new TypeError('options.headers must be an array of Strings');
 
-      var h = options.headers[i].toLowerCase();
+      var h = headers[i].toLowerCase();
 
       if (h === 'request-line') {
         if (!options.strict) {
@@ -373,7 +374,7 @@ module.exports = {
         stringToSign += h + ': ' + value;
       }
 
-      if ((i + 1) < options.headers.length)
+      if ((i + 1) < headers.length)
         stringToSign += '\n';
     }
 
@@ -409,7 +410,7 @@ module.exports = {
     request.setHeader(authzHeaderName, sprintf(FMT,
       options.keyId,
       options.algorithm,
-      options.headers.join(' '),
+      headers.join(' '),
       signature));
 
     return true;

--- a/lib/signer.js
+++ b/lib/signer.js
@@ -17,7 +17,7 @@ var validateAlgorithm = utils.validateAlgorithm;
 
 ///--- Globals
 
-var AUTHZ_PARAMS = [ 'keyId', 'algorithm', 'headers', 'signature' ];
+var AUTHZ_PARAMS = [ 'keyId', 'algorithm', 'opaque', 'headers', 'signature' ];
 
 ///--- Specific Errors
 
@@ -286,6 +286,7 @@ module.exports = {
     assert.object(options, 'options');
     assert.optionalString(options.algorithm, 'options.algorithm');
     assert.string(options.keyId, 'options.keyId');
+    assert.optionalString(options.opaque, 'options.opaque');
     assert.optionalArrayOfString(options.headers, 'options.headers');
     assert.optionalString(options.httpVersion, 'options.httpVersion');
 
@@ -363,6 +364,12 @@ module.exports = {
         stringToSign += '(keyid): ' + options.keyId;
       } else if (h === '(algorithm)') {
         stringToSign += '(algorithm): ' + options.algorithm;
+      } else if (h === '(opaque)') {
+        var value = options.opaque;
+        if (value == undefined || value === '') {
+          throw new MissingHeaderError('options.opaque was not in the request');
+        }
+        stringToSign += '(opaque): ' + value;
       } else {
         var value = request.getHeader(h);
         if (value === undefined || value === '') {
@@ -408,6 +415,8 @@ module.exports = {
       'algorithm': options.algorithm,
       'signature': signature,
     };
+    if (options.opaque)
+      params.opaque = options.opaque;
     if (options.headers)
       params.headers = options.headers.join(' ');
 

--- a/lib/signer.js
+++ b/lib/signer.js
@@ -31,6 +31,25 @@ function StrictParsingError(message) {
 }
 util.inherits(StrictParsingError, HttpSignatureError);
 
+function FormatAuthz(prefix, params) {
+  assert.string(prefix, 'prefix');
+  assert.object(params, 'params');
+
+  var authz = '';
+  for (var i = 0; i < AUTHZ_PARAMS.length; i++) {
+    var param = AUTHZ_PARAMS[i];
+    var value = params[param];
+    if (value === undefined)
+      continue;
+    assert.string(value, 'params.' + param);
+
+    authz += prefix + sprintf('%s="%s"', param, value);
+    prefix = ',';
+  }
+
+  return (authz);
+}
+
 /* See createSigner() */
 function RequestSigner(options) {
   assert.object(options, 'options');
@@ -187,11 +206,12 @@ RequestSigner.prototype.sign = function (cb) {
         assert.string(sig.signature, 'signature.signature');
         alg = validateAlgorithm(sig.algorithm);
 
-        authz = sprintf(AUTHZ_FMT,
-          sig.keyId,
-          sig.algorithm,
-          self.rs_headers.join(' '),
-          sig.signature);
+        authz = FormatAuthz('Signature ', {
+          keyId: sig.keyId,
+          algorithm: sig.keyId,
+          headers: self.rs_headers.join(' '),
+          signature: sig.signature
+        });
       } catch (e) {
         cb(e);
         return;
@@ -208,11 +228,12 @@ RequestSigner.prototype.sign = function (cb) {
     }
     alg = (this.rs_alg[0] || this.rs_key.type) + '-' + sigObj.hashAlgorithm;
     var signature = sigObj.toString();
-    authz = sprintf(AUTHZ_FMT,
-      this.rs_keyId,
-      alg,
-      this.rs_headers.join(' '),
-      signature);
+    authz = FormatAuthz('Signature ', {
+      keyId: this.rs_keyId,
+      algorithm: alg,
+      headers: this.rs_headers.join(' '),
+      signature: signature
+    });
     cb(null, authz);
   }
 };
@@ -413,25 +434,14 @@ module.exports = {
     var params = {
       'keyId': options.keyId,
       'algorithm': options.algorithm,
-      'signature': signature,
+      'signature': signature
     };
     if (options.opaque)
       params.opaque = options.opaque;
     if (options.headers)
       params.headers = options.headers.join(' ');
 
-    var authz = '';
-    for (i = 0; i < AUTHZ_PARAMS.length; i++) {
-      var key = AUTHZ_PARAMS[i];
-      var value = params[key];
-      if (value === undefined)
-        continue;
-
-      authz += prefix + sprintf('%s="%s"', key, value);
-      prefix = ',';
-    }
-
-    request.setHeader(authzHeaderName, authz);
+    request.setHeader(authzHeaderName, FormatAuthz(prefix, params));
 
     return true;
   }

--- a/test/signer.test.js
+++ b/test/signer.test.js
@@ -241,6 +241,27 @@ test('signing with unspecified algorithm', function(t) {
   req.end();
 });
 
+test('signing opaque param', function(t) {
+  var req = http.request(httpOptions, function(res) {
+    t.end();
+  });
+  var opts = {
+    keyId: 'unit',
+    key: rsaPrivate,
+    opaque: 'opaque',
+    headers: ['date', '(opaque)']
+  };
+
+  req._stringToSign = null;
+  t.ok(httpSignature.sign(req, opts));
+  t.ok(req.getHeader('Authorization'));
+  t.strictEqual(typeof (opts.algorithm), 'string');
+  t.strictEqual(typeof (req._stringToSign), 'string');
+  t.ok(req._stringToSign.match(/^date: [^\n]*\n\(opaque\): opaque$/));
+  console.log('> ' + req.getHeader('Authorization'));
+  req.end();
+});
+
 test('request-target with dsa key', function(t) {
   var req = http.request(httpOptions, function(res) {
     t.end();


### PR DESCRIPTION
the idea and semantics are largely copied from http digest auth, and is nicely described in [rfc2617](https://tools.ietf.org/html/rfc2617#section-3.2.1) when it's talking about generating the WWW-Authenticate header: 
    
>   opaque
>     A string of data, specified by the server, which should be returned
>     by the client unchanged in the Authorization header of subsequent
>     requests with URIs in the same protection space. It is recommended
>     that this string be base64 or hexadecimal data.
    
that rfc is obsoleted by [rfc7616](https://tools.ietf.org/html/rfc7616), which doesn't really change the semantics and use of opaque, it just takes more words to describe it. 
    
the idea is to use it to mitigate against the reuse of signature data between services, or "protection spaces" on the same service. if a 3rd party could capture the authorization header, we want to make it hard for them to replay it against another service to authenticate as the user.
    
the current best practice for that is to require that at least the `host` header and `(request-target)` pseudo-header (and maybe the `(keyid)`), and have them included included as input for the signature generation. this is fine, but this means the client cannot reuse a signature for multiple requests, it has to generate one per request because the uri changes. if they're using something like a yubikey to sign requests, and they're doing a lot of requests, this is slow.
    
using an "opaque" value can mitigate this. letting the server provide an "opaque" value as part of a WWW-Authenticate header in a 401 response means it can scope a "protection space" with an identifier it provides. you can then use "(opaque)" instead of "(request-target)" as an input to the signature. if servers provide unique opaque values, they can mitigate against reuse of the signature between services, while allowing a client to reuse a signature across multiple requests
to the same service.

to support adding `opaque="XXX"` to the Authorization header, I refactored the code that generates that header. this made it possible to make the `headers=""` param optional too, which I did as well. it also avoids mutating the headers part of the options object that callers give to sign and parse.