### PR TITLE
allow empty header

### DIFF
--- a/lib/signer.js
+++ b/lib/signer.js
@@ -393,7 +393,7 @@ module.exports = {
         stringToSign += '(opaque): ' + opaque;
       } else {
         var value = request.getHeader(h);
-        if (value === undefined || value === '') {
+        if (value === undefined) {
           throw new MissingHeaderError(h + ' was not in the request');
         }
         stringToSign += h + ': ' + value;


### PR DESCRIPTION
Resolves #107.

Only check if a header is undefined and not if it is empty to also allow an empty header.