### PR TITLE
Use Buffer.from() instead of new Buffer()

### DIFF
--- a/lib/verify.js
+++ b/lib/verify.js
@@ -73,7 +73,7 @@ module.exports = {
     h1.update(hmac.digest());
     h1 = h1.digest();
     var h2 = crypto.createHmac(hashAlg, secret);
-    h2.update(new Buffer(parsedSignature.params.signature, 'base64'));
+    h2.update(Buffer.from(parsedSignature.params.signature, 'base64'));
     h2 = h2.digest();
 
     /* Node 0.8 returns strings from .digest(). */

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "request"
   ],
   "engines": {
-    "node": ">=0.10"
+    "node": ">=4.9.1"
   },
   "main": "lib/index.js",
   "files": [


### PR DESCRIPTION
Avoid deprecation warning in nodejs12.x