### PR TITLE
Upgrade jsprim dependency to v 2.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "http-signature",
-  "version": "1.3.2",
+  "version": "1.3.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -155,9 +155,9 @@
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-2.0.1.tgz",
+      "integrity": "sha512-ykT6/hSq5BOLi+8v/a8Sq/FiS9s+N/Y5hjFY0Gv134uAk+GXEoMTVoq9Wgju8oG7laWpT198myOYeZVn8LUhtA==",
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "assert-plus": "^1.0.0",
-    "jsprim": "^1.2.2",
+    "jsprim": "^2.0.1",
     "sshpk": "^1.14.1"
   },
   "devDependencies": {


### PR DESCRIPTION
As noted in issue #123, http-signature has a [critical severity vulnerability](https://snyk.io/test/npm/json-schema/0.2.3) brought in by a transitive dependency through jsprim on json-schema v0.2.3.

node-jsprim has [a pull request](https://github.com/joyent/node-jsprim/pull/32) which fixes the vulnerability. 

This dependency upgrade to jsprim ^2.0.1 assumes the vulnerability fix will be released in jsprim version 2.0.n. Thus, http-signature would be positioned to receive that fix and pass it up the dependency chain whenever the jsprim patch is released.

This would improve the security of our [Bot Framework samples](https://github.com/microsoft/BotBuilder-Samples/issues/3594) and I expect a lot of other products. A typical dependency tree of our sample bots is:
```
echobot@1.0.0 C:\src\BotBuilder-Samples\samples\typescript_nodejs\02.echo-bot
-- restify@8.6.0
  -- http-signature@1.3.5
    -- jsprim@1.4.1
      -- json-schema@0.2.3
```