### PR TITLE
TRITON-2378 Update sshpk for ed25519 support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "deps/javascriptlint"]
 	path = deps/javascriptlint
-	url = git@github.com:joyent/javascriptlint
+	url = https://github.com/TritonDataCenter/javascriptlint
 [submodule "deps/jsstyle"]
 	path = deps/jsstyle
-	url = git@github.com:joyent/jsstyle
+	url = https://github.com/TritonDataCenter/jsstyle

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@
 
 (nothing yet)
 
+## 1.4.0
+
+* Update sshpk for ed25519 support
+
 ## 1.3.6
 
 * Update jsprim due to vulnerability in json-schema (#123)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -13,7 +13,8 @@ var HASH_ALGOS = {
 var PK_ALGOS = {
   'rsa': true,
   'dsa': true,
-  'ecdsa': true
+  'ecdsa': true,
+  'ed25519': true
 };
 
 var HEADER = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -223,9 +223,9 @@
       "dev": true
     },
     "sshpk": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
-      "integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
+      "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "http-signature",
-  "version": "1.3.6",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -11,9 +11,9 @@
       "dev": true
     },
     "asn1": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
       "requires": {
         "safer-buffer": "~2.1.0"
       }
@@ -26,7 +26,7 @@
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
       "requires": {
         "tweetnacl": "^0.14.3"
       }
@@ -78,7 +78,7 @@
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -109,7 +109,7 @@
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -123,7 +123,7 @@
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -147,7 +147,7 @@
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
     },
     "json-schema": {
       "version": "0.4.0",
@@ -223,9 +223,9 @@
       "dev": true
     },
     "sshpk": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
+      "integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -259,12 +259,14 @@
       "dependencies": {
         "inherits": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz",
+          "integrity": "sha512-5KfXESjCAfFQel2TLqhr18NEz++UiWVIA0jwHzs2Kbvb3e+r+G/eVhRfoZbaPCL0PnERvK5YeMgh02O4eenufw==",
           "dev": true
         },
         "yamlish": {
           "version": "0.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/yamlish/-/yamlish-0.0.5.tgz",
+          "integrity": "sha512-KEJMAxL1YFn9gFSHgLUKLFGoAXmmMurdZle5DIk4VDUgLZybdp7MGzkCxQO7mVwmkHXfNQQmfmQ79KNR/Zsztw==",
           "dev": true
         }
       }
@@ -306,7 +308,7 @@
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
     },
     "uglify-js": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "assert-plus": "^1.0.0",
     "jsprim": "^2.0.2",
-    "sshpk": "^1.17.0"
+    "sshpk": "^1.18.0"
   },
   "devDependencies": {
     "tap": "0.4.2",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "http-signature",
   "description": "Reference implementation of Joyent's HTTP Signature scheme.",
-  "version": "1.3.6",
+  "version": "1.4.0",
   "license": "MIT",
-  "author": "Joyent, Inc",
+  "author": "MNX Cloud (mnx.io)",
   "contributors": [
     "Mark Cavage <mcavage@gmail.com>",
     "David I. Lehn <dil@lehn.org>",
@@ -11,10 +11,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/joyent/node-http-signature.git"
+    "url": "git://github.com/TritonDataCenter/node-http-signature.git"
   },
-  "homepage": "https://github.com/joyent/node-http-signature/",
-  "bugs": "https://github.com/joyent/node-http-signature/issues",
+  "homepage": "https://github.com/TritonDataCenter/node-http-signature/",
+  "bugs": "https://github.com/TritonDataCenter/node-http-signature/issues",
   "keywords": [
     "https",
     "request"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "assert-plus": "^1.0.0",
     "jsprim": "^2.0.2",
-    "sshpk": "^1.14.1"
+    "sshpk": "^1.17.0"
   },
   "devDependencies": {
     "tap": "0.4.2",


### PR DESCRIPTION

## Testing notes

- Confirmed that `make check test` succeeded.
- Pulled these changes into [smartdc-auth](https://github.com/TritonDataCenter/node-smartdc-auth/compare/master...TRITON-2378) and confirmed that  `make check test` succeeded
- Pulled these changes into [cloudapi](https://github.com/TritonDataCenter/sdc-cloudapi/compare/master...TRITON-2378) and confirmed that  `make check` succeeded and that I could install the changes via `sdcadm update -C experimental cloudapi@TRITON-2378-20231113T181023Z-g073fbb7`
- Finally, I pulled in these change to [node-triton](https://github.com/TritonDataCenter/node-triton/compare/TRITON-2378) (via smartdc-auth), removed all keys from my account except for an ED25519 key and confirmed that I could make Cloud API requests and provision instances. 